### PR TITLE
Making sure that we assign the new event listener in commitUpdate

### DIFF
--- a/renderer/tiny-dom.js
+++ b/renderer/tiny-dom.js
@@ -172,7 +172,13 @@ const hostConfig = {
 
         setStyles(domElement, finalStyles);
       } else if (newProps[propName] || typeof newProps[propName] === 'number') {
-        domElement.setAttribute(propName, newProps[propName]);
+        if (isEventName(propName)) {
+          const eventName = propName.toLowerCase().replace('on', '');
+          domElement.removeEventListener(eventName, oldProps[propName]);
+          domElement.addEventListener(eventName, newProps[propName]);
+        } else {
+          domElement.setAttribute(propName, newProps[propName]);
+        }
       } else {
         if (isEventName(propName)) {
           const eventName = propName.toLowerCase().replace('on', '');


### PR DESCRIPTION
I've made a simple example using hooks and hit a bug where the old listener was used. Because of that the state variable was still the same.

```js
function XXX() {
  const [ counter, setCounter ] = useState(0);
  console.log(counter);
  useEffect(() => {
    setCounter(42);
  }, [])

  return (
    <span style={ { cursor: 'pointer' } } onClick={ () => setCounter(counter + 1) }>
      XXX({ counter })
    </span>
  );
}
function App() {
  return (
    <XXX />
  );
}

Banana.render(<App />, document.querySelector('#root'));
```

All works fine until I click on the XXX(42) text. This is suppose to update the local state to 43 but it sets it to 1. And then no matter how many times I click it stays 1. I assume that it gets the initial value of 0 on every render.

P.S.
The [Issue](https://github.com/facebook/react/issues/16171) in the React repo.